### PR TITLE
Exampel of how acking + controlled parallelism could look

### DIFF
--- a/src/main/java/woe/simulator/HttpClient.java
+++ b/src/main/java/woe/simulator/HttpClient.java
@@ -48,6 +48,8 @@ class HttpClient {
           if (r.status().isSuccess()) {
             return Jackson.unmarshaller(TelemetryResponse.class).unmarshal(r.entity(), materializer);
           } else {
+            // make sure you don't leak connections here for non-success
+            r.discardEntityBytes(materializer);
             return CompletableFuture.completedFuture(new TelemetryResponse(r.status().reason(), r.status().intValue(), telemetryRequest));
           }
         });

--- a/src/main/java/woe/simulator/WorldMap.java
+++ b/src/main/java/woe/simulator/WorldMap.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.IntStream;
 
 interface WorldMap {
@@ -15,7 +12,8 @@ interface WorldMap {
   int zoomMax = 18;
 
   static String entityIdOf(Region region) {
-    return String.format("region:%d:%1.13f:%1.13f:%1.13f:%1.13f", region.zoom,
+    // Unless you hardcode locale this will give you a localized decimal separator format (, vs .)
+    return String.format(Locale.US, "region:%d:%1.13f:%1.13f:%1.13f:%1.13f", region.zoom,
         region.topLeft.lat, region.topLeft.lng, region.botRight.lat, region.botRight.lng);
   }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -61,11 +61,28 @@ akka {
 }
 
 woe {
-  simulator.http.server {
-    host = "localhost"
-    host = ${?woe_simulator_http_server_host}
-    port = 8080
-    port = ${?woe_simulator_http_server_port}
+  simulator {
+
+    http.server {
+      host = "localhost"
+      host = ${?woe_simulator_http_server_host}
+      port = 8080
+      port = ${?woe_simulator_http_server_port}
+      # timeout for the complete operation before returning a
+      # failure to the http request, will not mean the request
+      # was aborted though, and will trigger a lot of work so
+      # must be as long as the longest query (but note that a
+      # http client will likely time out way before this)
+      # this is quite crazy - who would wait 10 minutes for a http request to complete
+      # (but note that it only makes it visible how it always was)
+      operation-timeout = 10m
+    }
+    # the max request time to delegate to subregions
+    # can currently span the entire set of zoom levels (could be changed to a factor depending on level perhaps)
+    # so needs to be high (but kind of shows the madness of this all)
+    subregion-request-timeout = 10m
+    # how many not-yet-completed requests to subregions are allowed at a time per region/request
+    subregion-request-parallelism = 20
   }
   twin {
     region-ping-interval-iso-8601 = "PT1M"

--- a/src/test/java/woe/simulator/HttpServerTest.java
+++ b/src/test/java/woe/simulator/HttpServerTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static woe.simulator.WorldMap.regionForZoom0;
 
 public class HttpServerTest {
-  private static HttpServer httpServer;
   private static String selectionUrl;
 
   @ClassRule
@@ -55,7 +54,7 @@ public class HttpServerTest {
 
     String host = testKit.system().settings().config().getString("woe.simulator.http.server.host");
     int port = testKit.system().settings().config().getInt("woe.simulator.http.server.port");
-    httpServer = HttpServer.start(host, port, testKit.system());
+    HttpServer.start(host, port, testKit.system());
     selectionUrl = String.format("http://%s:%d/selection", host, port);
   }
 
@@ -66,8 +65,6 @@ public class HttpServerTest {
     // Submit request to create a selected region in London across Westminster Bridge at Park Plaza Hotel
     WorldMap.Region region = WorldMap.regionAtLatLng(16, new WorldMap.LatLng(51.50079211, -0.11682093));
     HttpServer.SelectionActionRequest selectionActionRequest = new HttpServer.SelectionActionRequest("create", region);
-
-    httpServer.replyTo(probe.ref()); // hack to pass probe ref to entity messages
 
     HttpResponse httpResponse = Http.get(testKit.system().classicSystem())
         .singleRequest(HttpRequest.POST(selectionUrl)
@@ -127,7 +124,7 @@ public class HttpServerTest {
   }
 
   private static Materializer materializer() {
-    return Materializer.matFromSystem(testKit.system().classicSystem());
+    return Materializer.matFromSystem(testKit.system());
   }
 
   private static String entityAsString(HttpResponse httpResponse, Materializer materializer) {

--- a/src/test/java/woe/simulator/RegionTest.java
+++ b/src/test/java/woe/simulator/RegionTest.java
@@ -1,5 +1,6 @@
 package woe.simulator;
 
+import akka.Done;
 import akka.actor.ActorSystem;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
@@ -14,6 +15,7 @@ import akka.http.javadsl.marshallers.jackson.Jackson;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.model.headers.RawHeader;
 import akka.http.javadsl.server.Route;
+import akka.pattern.StatusReply;
 import akka.stream.Materializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
@@ -73,7 +75,7 @@ public class RegionTest {
   @Ignore
   public void createZoom18Selection() {
     testKit.system().log().debug("enter createZoom18Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 18;
     String entityId = entityIdOf(regionForZoom0());
@@ -83,7 +85,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(1, Duration.ofSeconds(30));
+    probe.receiveMessage();
     testKit.system().log().debug("exit createZoom18Selection");
   }
 
@@ -91,7 +93,7 @@ public class RegionTest {
   @Test
   public void createZoom17Selection() {
     testKit.system().log().debug("enter createZoom17Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 17;
     String entityId = entityIdOf(regionForZoom0());
@@ -101,7 +103,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(4, Duration.ofSeconds(30));
+    probe.receiveMessage(Duration.ofSeconds(30));
     testKit.system().log().debug("exit createZoom17Selection");
   }
 
@@ -109,7 +111,7 @@ public class RegionTest {
   @Test
   public void createZoom16Selection() {
     testKit.system().log().debug("enter createZoom16Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 16;
     String entityId = entityIdOf(regionForZoom0());
@@ -119,14 +121,14 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(16, Duration.ofSeconds(60));
+    probe.receiveMessage(Duration.ofSeconds(60));
     testKit.system().log().debug("exit createZoom16Selection");
   }
 
   @Test
   public void createZoom15Selection() {
     testKit.system().log().debug("enter createZoom15Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 15;
     String entityId = entityIdOf(regionForZoom0());
@@ -136,7 +138,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(64, Duration.ofSeconds(30));
+    probe.receiveMessage(Duration.ofSeconds(30));
     testKit.system().log().debug("exit createZoom15Selection");
   }
 
@@ -144,7 +146,7 @@ public class RegionTest {
   @Test
   public void createZoom13Selection() {
     testKit.system().log().debug("enter createZoom15Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 13;
     String entityId = entityIdOf(regionForZoom0());
@@ -154,7 +156,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(1024, Duration.ofSeconds(30));
+    probe.receiveMessage(Duration.ofSeconds(30));
     testKit.system().log().debug("exit createZoom15Selection");
   }
 
@@ -162,7 +164,7 @@ public class RegionTest {
   @Test
   public void createZoom10Selection() {
     testKit.system().log().debug("enter createZoom10Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 10;
     String entityId = entityIdOf(regionForZoom0());
@@ -172,7 +174,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(65536, Duration.ofSeconds(60));
+    probe.receiveMessage(Duration.ofSeconds(60));
     testKit.system().log().debug("exit createZoom10Selection");
   }
 
@@ -180,7 +182,7 @@ public class RegionTest {
   @Test
   public void createZoom09Selection() {
     testKit.system().log().debug("enter createZoom09Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 9;
     String entityId = entityIdOf(regionForZoom0());
@@ -190,7 +192,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(262144, Duration.ofSeconds(60));
+    probe.receiveMessage(Duration.ofSeconds(60));
     testKit.system().log().debug("exit createZoom09Selection");
   }
 
@@ -198,7 +200,7 @@ public class RegionTest {
   @Test
   public void createZoom08Selection() {
     testKit.system().log().debug("enter createZoom08Selection");
-    TestProbe<Region.Command> probe = testKit.createTestProbe();
+    TestProbe<StatusReply<Done>> probe = testKit.createTestProbe();
 
     int zoom = 8;
     String entityId = entityIdOf(regionForZoom0());
@@ -208,7 +210,7 @@ public class RegionTest {
     WorldMap.Region region = regionAtLatLng(zoom, new LatLng(51.50079211, -0.11682093));
     entityRef.tell(new Region.SelectionCreate(region, probe.ref()));
 
-    probe.receiveSeveralMessages(1048576, Duration.ofMinutes(10));
+    probe.receiveMessage(Duration.ofMinutes(10));
     testKit.system().log().debug("exit createZoom08Selection");
   }
 

--- a/src/test/resources/application-test.conf
+++ b/src/test/resources/application-test.conf
@@ -54,9 +54,14 @@ akka {
 }
 
 woe {
-  simulator.http.server {
-    host = "localhost"
-    port = 8081
+  simulator {
+    http.server {
+      host = "localhost"
+      port = 8081
+      operation-timeout = 10m
+    }
+    subregion-request-parallelism = 20
+    subregion-request-timeout = 10m
   }
   twin.http.server {
     host = "localhost"


### PR DESCRIPTION
Here's a quick shot at doing ack:ing with configurable parallelism.

I think it brings at least one consequence to the surface that would never be acceptable in a real world app and that is that the entire request takes minutes to fulfill, even with an in mem journal and local http server for the twin. It could be a good idea to take a step back and consider either redesign to optimize for the top-level-all-levels-down case or disallow it down to some zoom level where you know it does not overwhelm the system (to not make it super easy for users to DoS the system). 